### PR TITLE
docs: correct spelling typo in README.mdx of RSCs (#1)

### DIFF
--- a/exercises/02.server-components/01.problem.rsc/README.mdx
+++ b/exercises/02.server-components/01.problem.rsc/README.mdx
@@ -58,7 +58,7 @@ Once you have that done, you can restart your dev server and for any package
 that has a special export for an RSC environment, Node will resolve to that
 version of the package.
 
-📜 You can learn more about the benefits of this decion from
+📜 You can learn more about the benefits of this decision from
 [the Server Module Conventions RSC](https://github.com/reactjs/rfcs/blob/main/text/0227-server-module-conventions.md)
 
 ## 👨‍💼 Continue

--- a/exercises/02.server-components/04.problem.server-context/README.mdx
+++ b/exercises/02.server-components/04.problem.server-context/README.mdx
@@ -40,7 +40,7 @@ import { AsyncLocalStorage } from 'node:async_hooks'
 
 const userStorage = new AsyncLocalStorage()
 
-// somwhere later in your code
+// somewhere later in your code
 const user = await getUser()
 try {
 	userStorage.run(user, () => {


### PR DESCRIPTION
* docs: correct spelling typo in README.mdx of RSCs

* docs: correct spelling in server-context README of server-components